### PR TITLE
"dr4g0n b4ll" vm link fix

### DIFF
--- a/_data/curls.yml
+++ b/_data/curls.yml
@@ -1527,6 +1527,7 @@
   label: <a target="_blank" class="newicon" href="https://www.vulnhub.com/entry/r-temis-1,649/"><img src="assets/vulnhub.png"></a>
 "kb-vuln 4 final":
   label: <a target="_blank" class="newicon" href="https://www.vulnhub.com/entry/kb-vuln-4-final,648/"><img src="assets/vulnhub.png"></a>
+"dr4g0n b4ll":
   label: <a target="_blank" class="newicon" href="https://www.vulnhub.com/entry/dr4g0n-b4ll-1,646/"><img src="assets/vulnhub.png"></a>
 "finding my friend":
   label: <a target="_blank" class="newicon" href="https://www.vulnhub.com/entry/finding-my-friend-1,645/"><img src="assets/vulnhub.png"></a>


### PR DESCRIPTION
said vm had no link so it's corrected.